### PR TITLE
Use env vars for DB settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Codex Project
+
+This project requires database credentials to be provided via environment variables.
+
+## Required Environment Variables
+
+- `DB_HOST` - Database host
+- `DB_USER` - Database user name
+- `DB_PASSWORD` - Database user password
+- `DB_NAME` - Database name to connect to
+
+These variables are used by `lib/Db.class.php` when establishing a database connection.
+The file `lib/settings.ini.php` provides an example configuration referencing these variables.

--- a/lib/Db.class.php
+++ b/lib/Db.class.php
@@ -45,19 +45,21 @@ class DB
        /**
 	*	This method makes connection to the database.
 	*	
-	*	1. Reads the database settings from a ini file. 
-	*	2. Puts  the ini content into the settings array.
-	*	3. Tries to connect to the database.
-	*	4. If connection failed, exception is displayed and a log file gets created.
+	*	1. Reads the database settings from environment variables. 
+	*	2. Tries to connect to the database.
+	*	3. If connection failed, exception is displayed and a log file gets created.
 	*/
 		private function Connect()
 		{
-			$this->settings = parse_ini_file("settings.ini.php");
-			$dsn = 'mysql:dbname='.$this->settings["dbname"].';host='.$this->settings["host"].'';
+                        $host = getenv("DB_HOST");
+                        $user = getenv("DB_USER");
+                        $password = getenv("DB_PASSWORD");
+                        $dbname = getenv("DB_NAME");
+                        $dsn = "mysql:dbname=".$dbname.";host=".$host;
 			try 
 			{
-				# Read settings from INI file, set UTF8
-				$this->pdo = new PDO($dsn, $this->settings["user"], $this->settings["password"], array(PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"));
+                                # Create PDO connection using environment settings
+                                $this->pdo = new PDO($dsn, $user, $password, array(PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"));
 				
 				# We can now log any exceptions on Fatal error. 
 				$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/lib/settings.ini.php
+++ b/lib/settings.ini.php
@@ -1,5 +1,6 @@
 [SQL]
-host = localhost
-user = df77_kingseojin
-password = "elvor0810!"
-dbname = df77_kingseojin
+; Database connection settings sourced from environment variables
+host = ${DB_HOST}
+user = ${DB_USER}
+password = ${DB_PASSWORD}
+dbname = ${DB_NAME}


### PR DESCRIPTION
## Summary
- replace credentials in `lib/settings.ini.php` with environment variable placeholders
- update `Db.class.php` to read configuration from `getenv()`
- document required environment variables in new `README.md`

## Testing
- `php -l lib/Db.class.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684648b0eed08322975fa2db614234de